### PR TITLE
[#17] Improve Button Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,19 @@ Package.resolved
 .swiftpm
 .build/
 xcuserdata
+
+## macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+*.icloud
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,126 @@
+# File options
+
+--exclude Pods
+
+# Rules
+
+## Enabled
+--enable andOperator
+--enable anyObjectProtocol
+--enable assertionFailures
+--enable blankLinesBetweenScopes
+--enable blockComments
+--enable braces
+--enable consecutiveBlankLines
+--enable consecutiveSpaces
+--enable duplicateImports
+--enable elseOnSameLine
+--enable emptyBraces
+--enable extensionAccessControl
+--enable fileHeader
+--enable hoistPatternLet
+--enable initCoderUnavailable
+--enable isEmpty
+--enable leadingDelimiters
+--enable linebreakAtEndOfFile
+--enable linebreaks
+--enable modifierOrder
+--enable preferKeyPath
+--enable redundantBackticks
+--enable redundantBreak
+--enable redundantClosure
+--enable redundantExtensionACL
+--enable redundantFileprivate
+--enable redundantGet
+--enable redundantInit
+--enable redundantLet
+--enable redundantLetError
+--enable redundantNilInit
+--enable redundantObjc
+--enable redundantParens
+--enable redundantPattern
+--enable redundantRawValues
+--enable redundantReturn
+--enable redundantSelf
+--enable redundantType
+--enable redundantVoidReturnType
+--enable semicolons
+--enable sortedImports
+--enable sortedSwitchCases
+--enable spaceAroundBraces
+--enable spaceAroundBrackets
+--enable spaceAroundComments
+--enable spaceAroundGenerics
+--enable spaceAroundOperators
+--enable spaceAroundParens
+--enable spaceInsideBraces
+--enable spaceInsideBrackets
+--enable spaceInsideComments
+--enable spaceInsideGenerics
+--enable spaceInsideParens
+--enable strongifiedSelf
+--enable strongOutlets
+--enable todos
+--enable trailingClosures
+--enable trailingSpace
+--enable typeSugar
+--enable void
+--enable wrapEnumCases
+--enable yodaConditions
+
+## Disabled
+--disable acronyms                            # -> More often than not this breaks API and Backend Call Implementations
+--disable blankLinesAroundMark                # -> Normally correct, but not for Comments after the MARK
+--disable blankLinesAtEndOfScope              # -> disabled until it is possible to add 1 line for classes, structs & enums, but 0 for func etc. --> https://github.com/nicklockwood/SwiftFormat/issues/261
+--disable blankLinesAtStartOfScope            # -> disabled until it is possible to add 1 line for classes, structs & enums, but 0 for func etc. --> https://github.com/nicklockwood/SwiftFormat/issues/261
+--disable blankLinesBetweenImports            # -> Normally correct, but I write the @testable import first, then a blank line and then the alphabetized list of imports
+--disable enumNamespaces                      # -> Caseless enums should be avoided in my opinion
+--disable indent                              # -> This destroys clarity in too many cases
+--disable markTypes                           # -> MARK Comments are not always preferential
+--disable numberFormatting                    # -> When working on banking related projects we have different formatting for things like bank codes than we have on normal numbers. Those can't be automatically detected.
+--disable organizeDeclarations                # -> Properties & Methods sometimes have more clarity when ordered semantically
+--disable sortDeclarations                    # -> Too much overhead having to write // swiftformat:sort in files
+--disable trailingCommas                      # -> A comma after the last element of a collection is never necessary
+--disable unusedArguments                     # -> This destroys some Protocol implementations (applicationDidLaunch etc.)
+--disable wrap                                # -> I have a widescreen monitor, I don't need wrapping
+--disable wrapArguments                       # -> Normally I don't wrap arguments and if I do, it is decided on a case-by-case basis
+--disable wrapAttributes                      # -> Wanted behavior: prev-line for func and computed properties, same-line for normal properties and types --> https://github.com/nicklockwood/SwiftFormat/issues/1232
+--disable wrapConditionalBodies               # -> Please don't! 1 line guard statements should always be written in one line in my opinion
+--disable wrapSwitchCases                     # -> Sometimes having all cases in one line is okay!
+--disable wrapMultilineStatementBraces        # -> Objective-C is dying for many reasons ... and this is one of them!
+
+# Format options
+
+--allman false
+--closurevoid remove
+--elseposition same-line
+--emptybraces spaced
+--extensionacl on-extension
+--guardelse same-line
+--header "\n📄 {file}\n👨🏼‍💻 Author: Tobias Gleiss\n"
+--ifdef indent
+--importgrouping alpha
+--indent 4
+--indentcase false
+--linebreaks lf
+--modifierorder optional,required,convenience,override,indirect,private,fileprivate,internal,public,open,private(set),fileprivate(set),internal(set),public(set),final,dynamic,lazy,static,class,weak,unowned,mutating,nonmutating,prefix,postfix
+--operatorfunc spaced
+--patternlet hoist
+--ranges spaced
+--redundanttype inferred
+--self init-only
+--semicolons inline
+--shortoptionals always
+--smarttabs enabled
+--stripunusedargs always
+--swiftversion 5.6
+--tabwidth 4
+--trimwhitespace always
+--voidtype void
+--xcodeindentation disabled
+--yodaswap always
+
+# Wait for wrapAttributes to support differentiation of stored and computed properties --> https://github.com/nicklockwood/SwiftFormat/issues/1232
+# --funcattributes prev-line
+# --typeattributes prev-line
+# --varattributes same-line # but not for computed properties

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to SwiftUIMaterialDesignComponents! This package tries to recreate sever
 
 The Material Design circular [Activity Indicator](https://m2.material.io/components/progress-indicators#usage) (or progress indicator).
 
-<img alt="SwiftUIMDActivityIndicator" src="https://raw.githubusercontent.com/tobiasgleiss/SwiftUIMaterialDesignComponents/develop/Sources/Readme/SwiftUIMDActivityIndicator.gif" height="100"/>
+<img alt="SwiftUIMDActivityIndicator" src="Sources/Readme/SwiftUIMDActivityIndicator.gif?raw=1" height="100"/>
 
 Basic usage:
 ```sh
@@ -25,7 +25,7 @@ You can customize these style options further with creating your own styles with
 
 ## Contained Button
 
-<img alt="SwiftUIMDButton Contained" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDButton_Contained.gif?raw=true" height="75"/>
+<img alt="SwiftUIMDButton Contained" src="Sources/Readme/SwiftUIMDButton_Contained.gif?raw=1" height="75"/>
 
 Basic usage:
 ```sh
@@ -34,7 +34,7 @@ SwiftUIMDButton(title: "My Contained Button", style: .contained())
 
 ## Outlined Button
 
-<img alt="SwiftUIMDButton Outlined" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDButton_Outlined.gif?raw=true" height="75"/>
+<img alt="SwiftUIMDButton Outlined" src="Sources/Readme/SwiftUIMDButton_Outlined.gif?raw=1" height="75"/>
 
 Basic usage:
 ```sh
@@ -43,7 +43,7 @@ SwiftUIMDButton(title: "My Outlined Button", style: .outlined())
 
 ## Text Button
 
-<img alt="SwiftUIMDButton Text" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDButton_Text.gif?raw=true" height="75"/>
+<img alt="SwiftUIMDButton Text" src="Sources/Readme/SwiftUIMDButton_Text.gif?raw=1" height="75"/>
 
 Basic usage:
 ```sh
@@ -65,7 +65,7 @@ You can customize these style options further with creating your own styles with
 
 ## Filled TextField
 
-<img alt="SwiftUIMDTextField Filled" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDTextField_Filled.gif?raw=true" height="125"/>
+<img alt="SwiftUIMDTextField Filled" src="Sources/Readme/SwiftUIMDTextField_Filled.gif?raw=1" height="125"/>
 
 Basic usage:
 ```sh
@@ -78,7 +78,7 @@ SwiftUIMDTextField(placeholder: "My Filled TextField", style: .filled(), value: 
 
 ## Filled Secured TextField
 
-<img alt="SwiftUIMDTextField Filled Secured" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDTextField_FilledSecured.gif?raw=true" height="125"/>
+<img alt="SwiftUIMDTextField Filled Secured" src="Sources/Readme/SwiftUIMDTextField_FilledSecured.gif?raw=1" height="125"/>
 
 Basic usage:
 ```sh
@@ -91,7 +91,7 @@ SwiftUIMDTextField(placeholder: "My Filled Secured TextField", style: .filledSec
 
 ## Outlined TextField
 
-<img alt="SwiftUIMDTextField Outlined" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDTextField_Outlined.gif?raw=true" height="125"/>
+<img alt="SwiftUIMDTextField Outlined" src="Sources/Readme/SwiftUIMDTextField_Outlined.gif?raw=1" height="125"/>
 
 Basic usage:
 ```sh
@@ -105,7 +105,7 @@ SwiftUIMDTextField(placeholder: "My Outlined TextField", style: .outlined(), val
 
 ## Outlined Secured TextField
 
-<img alt="SwiftUIMDTextField Outlined" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDTextField_OutlinedSecured.gif?raw=true" height="125"/>
+<img alt="SwiftUIMDTextField Outlined" src="Sources/Readme/SwiftUIMDTextField_OutlinedSecured.gif?raw=1" height="125"/>
 
 Basic usage:
 ```sh
@@ -122,7 +122,7 @@ The Material Design Ripple Effect. Please have a look at the initializer documen
 
 **Note**: The SwiftUIMDButton has the Ripple Effect already built in. 
 
-<img alt="SwiftUIMDRippleEffect" src="https://github.com/tobiasgleiss/SwiftUIMaterialDesignComponents/blob/develop/Sources/Readme/SwiftUIMDRippleEffect.gif?raw=true" height="125"/>
+<img alt="SwiftUIMDRippleEffect" src="Sources/Readme/SwiftUIMDRippleEffect.gif?raw=1" height="125"/>
 
 Basic usage:
 ```sh

--- a/Sources/SwiftUIMaterialDesignComponents/Custom/AnimationObserverModifier.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Custom/AnimationObserverModifier.swift
@@ -1,6 +1,6 @@
 //
 // 📄 AnimationObserverModifier.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI
@@ -19,30 +19,30 @@ public struct AnimationObserverModifier<Value>: AnimatableModifier where Value: 
     private var onMatchExecute: () -> Void
     private var onCompletionExecute: () -> Void
 
-    init(observedValue: Value, matchValue: Value? = nil, onMatchExecute: @escaping () -> Void = {}, onCompletionExecute: @escaping () -> Void = {}) {
+    init(observedValue: Value, matchValue: Value? = nil, onMatchExecute: @escaping () -> Void = { }, onCompletionExecute: @escaping () -> Void = { }) {
         self.animatableData = observedValue
         self.matchValue = matchValue
         self.targetValue = observedValue
         self.onMatchExecute = onMatchExecute
         self.onCompletionExecute = onCompletionExecute
     }
-    
+
     private func notifyIfValueMatched() {
         guard animatableData == matchValue else { return }
         DispatchQueue.main.async {
-            self.onMatchExecute()
+            onMatchExecute()
         }
     }
 
     private func notifyCompletionIfFinished() {
         guard animatableData == targetValue else { return }
         DispatchQueue.main.async {
-            self.onCompletionExecute()
+            onCompletionExecute()
         }
     }
 
     public func body(content: Content) -> some View {
         content
     }
-    
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/Custom/ConditionalFrameModifier.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Custom/ConditionalFrameModifier.swift
@@ -1,15 +1,15 @@
 //
 // 📄 ConditionalFrameModifier.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI
 
 internal struct ConditionalFrameModifier: ViewModifier {
-    
+
     var isActive: Bool
     var width: CGFloat
-    
+
     @ViewBuilder func body(content: Content) -> some View {
         if isActive {
             content
@@ -18,5 +18,5 @@ internal struct ConditionalFrameModifier: ViewModifier {
             content
         }
     }
-    
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/Custom/HiddenModifier.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Custom/HiddenModifier.swift
@@ -1,6 +1,6 @@
 //
 // 📄 HiddenModifier.swift
-// 👨🏼‍💻 Author: Benno Kress (https://github.com/bennokress)
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI

--- a/Sources/SwiftUIMaterialDesignComponents/Custom/RoundedCornerShape.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Custom/RoundedCornerShape.swift
@@ -1,15 +1,15 @@
 //
-// 📄 TouchLocationModifier.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 📄 RoundedCornerShape.swift
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI
 
 internal struct RoundedCornerShape: Shape {
-    
+
     var radius: CGFloat = .infinity
     var corners: UIRectCorner = .allCorners
-    
+
     func path(in rect: CGRect) -> Path {
         let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
         return Path(path.cgPath)

--- a/Sources/SwiftUIMaterialDesignComponents/Custom/TouchLocationModifier.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Custom/TouchLocationModifier.swift
@@ -1,8 +1,7 @@
 //
 // 📄 TouchLocationModifier.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
-
 
 import SwiftUI
 

--- a/Sources/SwiftUIMaterialDesignComponents/Extensions/EnvironmentValues.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Extensions/EnvironmentValues.swift
@@ -1,6 +1,6 @@
 //
 // 📄 EnvironmentValues.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI
@@ -30,7 +30,7 @@ private struct TextFieldErrorMessage: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    
+
     var activityIndicatorColor: Color {
         get { self[ActivityIndicatorColor.self] }
         set { self[ActivityIndicatorColor.self] = newValue }
@@ -45,17 +45,17 @@ extension EnvironmentValues {
         get { self[ActivityIndicatorStrokeWidth.self] }
         set { self[ActivityIndicatorStrokeWidth.self] = newValue }
     }
-    
+
     var isButtonPending: Bool {
         get { self[ButtonPendingState.self] }
         set { self[ButtonPendingState.self] = newValue }
     }
-    
+
     var buttonTapAreaInsets: EdgeInsets {
         get { self[ButtonTapAreaInsets.self] }
         set { self[ButtonTapAreaInsets.self] = newValue }
     }
-    
+
     var textFieldErrorMessage: String {
         get { self[TextFieldErrorMessage.self] }
         set { self[TextFieldErrorMessage.self] = newValue }
@@ -63,7 +63,7 @@ extension EnvironmentValues {
 }
 
 extension EdgeInsets {
-    
+
     static let zero = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-    
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/Extensions/View.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Extensions/View.swift
@@ -1,6 +1,6 @@
 //
 // 📄 View.swift
-// 👨‍💻 Author: Tobias Gleiss
+// 👨🏼‍💻 Author: Tobias Gleiss
 //
 
 import SwiftUI
@@ -13,7 +13,7 @@ extension View {
     @discardableResult public func pending(_ isPending: Bool) -> some View {
         environment(\.isButtonPending, isPending)
     }
-    
+
     /// Sets the color of the SwiftUIMDActivityIndicator
     /// - Parameter color: The color to be used
     /// - Returns: The SwiftUIMDActivityIndicator using the specifed color.
@@ -34,9 +34,9 @@ extension View {
     @discardableResult public func activityIndicatorStrokeWidth(_ strokeWidth: CGFloat) -> some View {
         environment(\.activityIndicatorStrokeWidth, strokeWidth)
     }
-    
+
     /// Increases the tap area around a SwiftUIMDButton. This is especially helpful on horizontally aligned text only buttons.
-    /// - Parameters: 
+    /// - Parameters:
     ///   - edges: The edges to inset
     ///   - length: The length of the inset
     @discardableResult public func increaseButtonTapArea(_ edges: Edge.Set = .all, by length: CGFloat) -> some View {
@@ -46,18 +46,18 @@ extension View {
         let trailingInset = (edges == .all || edges == .horizontal || edges == .trailing) ? length : 0
         return increaseButtonTapArea(top: topInset, leading: leadingInset, bottom: bottomInset, trailing: trailingInset)
     }
-    
+
     /// Increases the tap area around a SwiftUIMDButton. This is especially helpful on horizontally aligned text only buttons.
-    /// - Parameters: 
+    /// - Parameters:
     ///   - top: The top inset
     ///   - leading: The leading inset
     ///   - bottom: The bottom inset
-    ///   - trailing: The trailing inset   
+    ///   - trailing: The trailing inset
     @discardableResult public func increaseButtonTapArea(top: CGFloat = 0, leading: CGFloat = 0, bottom: CGFloat = 0, trailing: CGFloat = 0) -> some View {
         let tapAreaInsets = EdgeInsets(top: top, leading: leading, bottom: bottom, trailing: trailing)
         return environment(\.buttonTapAreaInsets, tapAreaInsets)
     }
-    
+
     /// Calls the completion handler whenever an animation on the given value completes.
     /// - Parameters:
     ///   - value: The value to observe for animations.
@@ -66,7 +66,7 @@ extension View {
     @discardableResult internal func onAnimationCompleted<Value: VectorArithmetic>(for value: Value, onCompletionExecute: @escaping () -> Void) -> ModifiedContent<Self, AnimationObserverModifier<Value>> {
         modifier(AnimationObserverModifier(observedValue: value, onCompletionExecute: onCompletionExecute))
     }
-    
+
     /// Hide or show the view based on a boolean value.
     /// - Parameters:
     ///   - isHidden: Boolean value indicating whether or not to hide the view
@@ -87,36 +87,35 @@ extension View {
     @discardableResult internal func hidden(_ isHidden: Bool, andRemoved remove: Bool = false) -> some View {
         modifier(HiddenModifier(isHidden: isHidden, remove: remove))
     }
-    
+
     /// Sets the frame of the view based on a condition.
     @discardableResult internal func conditionalFrameWidth(_ width: CGFloat, if isActive: Bool) -> some View {
         modifier(ConditionalFrameModifier(isActive: isActive, width: width))
     }
-    
+
     /// Increases the Tap Area of the View by the given insets.
     @discardableResult internal func increaseTapArea(_ tapAreaInsets: EdgeInsets) -> some View {
-        self
-            .padding(tapAreaInsets)
+        padding(tapAreaInsets)
             .contentShape(Rectangle())
     }
-    
+
     /// Provides a Touch Gesture with options to execute actions on start, end or on cancel of the gesture.
     @discardableResult internal func onTouchGesture(onStarted: @escaping () -> Void, onLocationUpdate: @escaping (CGPoint) -> Void, onEnded: @escaping () -> Void, onCancelled: @escaping () -> Void) -> some View {
-        self.modifier(TouchLocationModifier(onStarted: onStarted, onLocationUpdate: onLocationUpdate, onEnded: onEnded, onCancelled: onCancelled))
+        modifier(TouchLocationModifier(onStarted: onStarted, onLocationUpdate: onLocationUpdate, onEnded: onEnded, onCancelled: onCancelled))
     }
-    
+
     /// Rounds one ore more specified corners to the given value.
     @discardableResult internal func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-            clipShape( RoundedCornerShape(radius: radius, corners: corners) )
+            clipShape(RoundedCornerShape(radius: radius, corners: corners))
         }
-    
+
     /// Manages the error message view of the SwiftUIMDTextField
     /// - Parameter errorMessage: The error message to be shown below a SwiftUIMDTextField
     /// - Returns: The input with all contained SwiftUIMDTextField showing/hiding the error message view with the specified message or the unchanged input otherwise.
     @discardableResult public func textFieldErrorMessage(_ errorMessage: String) -> some View {
         environment(\.textFieldErrorMessage, errorMessage)
     }
-    
+
     internal func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }

--- a/Sources/SwiftUIMaterialDesignComponents/Styles/MDButtonStyle.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Styles/MDButtonStyle.swift
@@ -5,12 +5,12 @@
 
 import SwiftUI
 
-public enum MDButtonStyle: Equatable {    
-    
+public enum MDButtonStyle: Equatable {
+
     case outlined(buttonColor: (normal: Color, disabled: Color) = (.mdOutlinedButtonDefaultColor, .mdOutlinedButtonDisabledDefaultColor), textColor: (normal: Color, disabled: Color) = (.mdOutlinedButtonCaptionDefaultColor, .mdOutlinedButtonCaptionDisabledDefaultColor), font: Font = .subheadline, borderWidth: CGFloat = 2, cornerRadius: CGFloat = 5, horizontalAlignment: HorizontalAlignment = .center, pendingIndicatorColor: Color = .mdOutlinedButtonPendingIndicatorDefaultColor)
     case contained(buttonColor: (normal: Color, disabled: Color) = (.mdContainedButtonDefaultColor, .mdContainedButtonDisabledDefaultColor), textColor: (normal: Color, disabled: Color) = (.mdContainedButtonCaptionDefaultColor, .mdContainedButtonCaptionDisabledDefaultColor), font: Font = .subheadline, borderWidth: CGFloat = 2, cornerRadius: CGFloat = 5, horizontalAlignment: HorizontalAlignment = .center, pendingIndicatorColor: Color = .mdContainedButtonPendingIndicatorDefaultColor)
     case text(buttonColor: (normal: Color, disabled: Color) = (.mdTextButtonDefaultColor, .mdTextButtonDisabledDefaultColor), textColor: (normal: Color, disabled: Color) = (.mdTextButtonCaptionDefaultColor, .mdTextButtonCaptionDisabledDefaultColor), font: Font = .subheadline, cornerRadius: CGFloat = 5, horizontalAlignment: HorizontalAlignment = .center, pendingIndicatorColor: Color = .mdTextButtonPendingIndicatorDefaultColor)
-    
+
     var buttonColor: (normal: Color, disabled: Color) {
         switch self {
         case let .outlined(buttonColor, _, _, _, _, _, _): return buttonColor
@@ -18,7 +18,7 @@ public enum MDButtonStyle: Equatable {
         case let .text(buttonColor, _, _, _, _, _): return buttonColor
         }
     }
-    
+
     var textColor: (normal: Color, disabled: Color) {
         switch self {
         case let .outlined(_, textColor, _, _, _, _, _): return textColor
@@ -26,7 +26,7 @@ public enum MDButtonStyle: Equatable {
         case let .text(_, textColor, _, _, _, _): return textColor
         }
     }
-    
+
     var buttonFont: Font {
         switch self {
         case let .outlined(_, _, buttonFont, _, _, _, _): return buttonFont
@@ -34,7 +34,7 @@ public enum MDButtonStyle: Equatable {
         case let .text(_, _, buttonFont, _, _, _): return buttonFont
         }
     }
-    
+
     var buttonBorderWidth: CGFloat {
         switch self {
         case let .outlined(_, _, _, borderWidth, _, _, _): return borderWidth
@@ -42,7 +42,7 @@ public enum MDButtonStyle: Equatable {
         case .text: return 0
         }
     }
-    
+
     var buttonCornerRadius: CGFloat {
         switch self {
         case let .outlined(_, _, _, _, cornerRadius, _, _): return cornerRadius
@@ -50,16 +50,16 @@ public enum MDButtonStyle: Equatable {
         case let .text(_, _, _, cornerRadius, _, _): return cornerRadius
         }
     }
-    
+
     var buttonAlignment: HorizontalAlignment {
         switch self {
         case let .outlined(_, _, _, _, _, horizontalAlignment, _): return horizontalAlignment
         case let .contained(_, _, _, _, _, horizontalAlignment, _): return horizontalAlignment
         case let .text(_, _, _, _, horizontalAlignment, _): return horizontalAlignment
-            
+
         }
     }
-    
+
     var rippleEffectColor: (whileActive: Color, whilePending: Color) {
         switch self {
         case .outlined: return (whileActive: buttonColor.normal, whilePending: .clear)
@@ -67,7 +67,7 @@ public enum MDButtonStyle: Equatable {
         case .text: return (whileActive: buttonColor.normal, whilePending: .clear)
         }
     }
-    
+
     var pendingIndicatorColor: Color {
         switch self {
         case let .outlined(_, _, _, _, _, _, pendingIndicatorColor): return pendingIndicatorColor
@@ -75,7 +75,7 @@ public enum MDButtonStyle: Equatable {
         case let .text(_, _, _, _, _, pendingIndicatorColor): return pendingIndicatorColor
         }
     }
-    
+
     var buttonElevationShadow: (radius: CGFloat, color: Color) {
         switch self {
         case .outlined: return (radius: 0, color: .clear)
@@ -83,9 +83,9 @@ public enum MDButtonStyle: Equatable {
         case .text: return (radius: 0, color: .clear)
         }
     }
-        
+
     public static func == (lhs: MDButtonStyle, rhs: MDButtonStyle) -> Bool {
-        return lhs.buttonColor == rhs.buttonColor &&
+        lhs.buttonColor == rhs.buttonColor &&
         lhs.textColor == rhs.textColor &&
         lhs.buttonFont == rhs.buttonFont &&
         lhs.buttonBorderWidth == rhs.buttonBorderWidth &&
@@ -94,11 +94,11 @@ public enum MDButtonStyle: Equatable {
         lhs.pendingIndicatorColor == rhs.pendingIndicatorColor &&
         lhs.buttonElevationShadow == rhs.buttonElevationShadow
     }
-    
+
 }
 
 extension MDButtonStyle {
-    
+
     var isText: Bool {
         switch self {
         case .text: return true
@@ -106,30 +106,30 @@ extension MDButtonStyle {
             return false
         }
     }
-    
+
 }
 
 public extension Color {
-    
+
     // Default values for Material Design outlined button
-    static let mdOutlinedButtonDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+    static let mdOutlinedButtonDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     static let mdOutlinedButtonDisabledDefaultColor: Color = .gray
-    static let mdOutlinedButtonCaptionDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+    static let mdOutlinedButtonCaptionDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     static let mdOutlinedButtonCaptionDisabledDefaultColor: Color = .gray
-    static let mdOutlinedButtonPendingIndicatorDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
-    
+    static let mdOutlinedButtonPendingIndicatorDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+
     // Default values for Material Design contained button
-    static let mdContainedButtonDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+    static let mdContainedButtonDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     static let mdContainedButtonDisabledDefaultColor: Color = .gray
     static let mdContainedButtonCaptionDefaultColor: Color = .white
     static let mdContainedButtonCaptionDisabledDefaultColor: Color = .white.opacity(0.5)
     static let mdContainedButtonPendingIndicatorDefaultColor: Color = .white
-    
+
     // Default values for Material Design text button
-    static let mdTextButtonDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+    static let mdTextButtonDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     static let mdTextButtonDisabledDefaultColor: Color = .clear
-    static let mdTextButtonCaptionDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+    static let mdTextButtonCaptionDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     static let mdTextButtonCaptionDisabledDefaultColor: Color = .gray
-    static let mdTextButtonPendingIndicatorDefaultColor: Color = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
-    
+    static let mdTextButtonPendingIndicatorDefaultColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/Styles/MDTextFieldStyle.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Styles/MDTextFieldStyle.swift
@@ -7,7 +7,7 @@ import Foundation
 import SwiftUI
 
 public enum MDTextFieldStyle: Equatable {
-    
+
     case filled(
         focusedColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultFocusedColor,
         textColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultTextColor,
@@ -24,7 +24,7 @@ public enum MDTextFieldStyle: Equatable {
         cornerRadius: CGFloat = MDTextFieldStyle.mdFilledTextFieldDefaultTopCornerRadius,
         padding: (horizontal: CGFloat, vertical: CGFloat) = (MDTextFieldStyle.mdFilledTextFieldDefaultHorizontalPadding, MDTextFieldStyle.mdFilledTextFieldDefaultVerticalPadding),
         iconSize: CGSize = MDTextFieldStyle.mdFilledTextFieldDefaultTrailingIconSize)
-    
+
     case filledSecured(
         focusedColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultFocusedColor,
         textColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultTextColor,
@@ -42,7 +42,7 @@ public enum MDTextFieldStyle: Equatable {
         padding: (horizontal: CGFloat, vertical: CGFloat) = (MDTextFieldStyle.mdFilledTextFieldDefaultHorizontalPadding, MDTextFieldStyle.mdFilledTextFieldDefaultVerticalPadding),
         iconSize: CGSize = MDTextFieldStyle.mdFilledTextFieldDefaultTrailingIconSize,
         securedByDefault: Bool = true)
-    
+
     // TODO: Remove background color from .outlined
     case outlined(
         focusedColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultFocusedColor,
@@ -60,7 +60,7 @@ public enum MDTextFieldStyle: Equatable {
         cornerRadius: CGFloat = MDTextFieldStyle.mdFilledTextFieldDefaultTopCornerRadius,
         padding: (horizontal: CGFloat, vertical: CGFloat) = (MDTextFieldStyle.mdFilledTextFieldDefaultHorizontalPadding, MDTextFieldStyle.mdFilledTextFieldDefaultVerticalPadding),
         iconSize: CGSize = MDTextFieldStyle.mdFilledTextFieldDefaultTrailingIconSize)
-    
+
     case outlinedSecured(
         focusedColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultFocusedColor,
         textColor: Color = MDTextFieldStyle.mdFilledTextFieldDefaultTextColor,
@@ -78,7 +78,7 @@ public enum MDTextFieldStyle: Equatable {
         padding: (horizontal: CGFloat, vertical: CGFloat) = (MDTextFieldStyle.mdFilledTextFieldDefaultHorizontalPadding, MDTextFieldStyle.mdFilledTextFieldDefaultVerticalPadding),
         iconSize: CGSize = MDTextFieldStyle.mdFilledTextFieldDefaultTrailingIconSize,
         securedByDefault: Bool = true)
-    
+
     var focusedColor: Color {
         switch self {
         case let .filled(color, _, _, _, _, _, _, _, _, _, _, _, _, _, _): return color
@@ -87,7 +87,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(color, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var textColor: Color {
         switch self {
         case let .filled(_, color, _, _, _, _, _, _, _, _, _, _, _, _, _): return color
@@ -96,7 +96,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, color, _, _, _, _, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var textColorDisabled: Color {
         switch self {
         case let .filled(_, _, color, _, _, _, _, _, _, _, _, _, _, _, _): return color
@@ -105,7 +105,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, color, _, _, _, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var backgroundColor: Color {
         switch self {
         case let .filled(_, _, _, color, _, _, _, _, _, _, _, _, _, _, _): return color
@@ -114,7 +114,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, color, _, _, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var backgroundColorDisabled: Color {
         switch self {
         case let .filled(_, _, _, _, color, _, _, _, _, _, _, _, _, _, _): return color
@@ -123,7 +123,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, color, _, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var borderColor: Color {
         switch self {
         case let .filled(_, _, _, _, _, color, _, _, _, _, _, _, _, _, _): return color
@@ -132,7 +132,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, color, _, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var borderColorDisabled: Color {
         switch self {
         case let .filled(_, _, _, _, _, _, color, _, _, _, _, _, _, _, _): return color
@@ -141,7 +141,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, color, _, _, _, _, _, _, _, _, _): return color
         }
     }
-    
+
     var textFieldHeight: CGFloat {
         switch self {
         case let .filled(_, _, _, _, _, _, _, height, _, _, _, _, _, _, _): return height
@@ -150,7 +150,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, height, _, _, _, _, _, _, _, _): return height
         }
     }
-    
+
     var errorFieldHeight: CGFloat {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, height, _, _, _, _, _, _): return height
@@ -159,7 +159,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, height, _, _, _, _, _, _, _): return height
         }
     }
-    
+
     var errorMessageFontSize: CGFloat {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, size, _, _, _, _, _): return size
@@ -168,7 +168,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, size, _, _, _, _, _, _): return size
         }
     }
-    
+
     var errorMessageColor: Color {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, _, color, _, _, _, _): return color
@@ -177,7 +177,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, color, _, _, _, _, _): return color
         }
     }
-    
+
     var errorMessageBackgroundColor: Color {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, _, _, color, _, _, _): return color
@@ -186,7 +186,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, _, color, _, _, _, _): return color
         }
     }
-    
+
     var cornerRadius: CGFloat {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, _, _, _, radius, _, _): return radius
@@ -195,7 +195,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, _, _, radius, _, _, _): return radius
         }
     }
-    
+
     var padding: (horizontal: CGFloat, vertical: CGFloat) {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, _, _, _, _, padding, _): return padding
@@ -204,7 +204,7 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, _, _, _, padding, _, _): return padding
         }
     }
-    
+
     var iconSize: CGSize {
         switch self {
         case let .filled(_, _, _, _, _, _, _, _, _, _, _, _, _, _, size): return size
@@ -213,18 +213,18 @@ public enum MDTextFieldStyle: Equatable {
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, _, _, _, _, size, _): return size
         }
     }
-    
+
     var isSecured: Bool {
         switch self {
-        case .filled(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _): return false
+        case .filled: return false
         case let .filledSecured(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, isSecured): return isSecured
-        case .outlined(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _): return false
+        case .outlined: return false
         case let .outlinedSecured(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, isSecured): return isSecured
         }
     }
-    
+
     public static func == (lhs: MDTextFieldStyle, rhs: MDTextFieldStyle) -> Bool {
-        return lhs.focusedColor == rhs.focusedColor &&
+        lhs.focusedColor == rhs.focusedColor &&
         lhs.textColor == rhs.textColor &&
         lhs.backgroundColor == rhs.backgroundColor &&
         lhs.borderColor == rhs.borderColor &&
@@ -238,7 +238,7 @@ public enum MDTextFieldStyle: Equatable {
         lhs.iconSize == rhs.iconSize &&
         lhs.isSecured == rhs.isSecured
     }
-    
+
     // Default values
     public static let mdFilledTextFieldDefaultHeight = CGFloat(56)
     public static let mdFilledTextFieldDefaultErrorFieldHeight = CGFloat(24)
@@ -247,7 +247,7 @@ public enum MDTextFieldStyle: Equatable {
     public static let mdFilledTextFieldDefaultVerticalPadding = CGFloat(12)
     public static let mdFilledTextFieldDefaultTopCornerRadius = CGFloat(5)
     public static let mdFilledTextFieldDefaultTrailingIconSize = CGSize(width: 24, height: 24)
-    
+
     // Default Colors
     public static let mdFilledTextFieldDefaultFocusedColor = Color(#colorLiteral(red: 0.3843137255, green: 0, blue: 0.9333333333, alpha: 1))
     public static let mdFilledTextFieldDefaultBackgroundColor = Color(#colorLiteral(red: 0.9254901961, green: 0.9254901961, blue: 0.9254901961, alpha: 1))

--- a/Sources/SwiftUIMaterialDesignComponents/Supporting Types/SwiftUIMDButtonIcon.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/Supporting Types/SwiftUIMDButtonIcon.swift
@@ -1,0 +1,65 @@
+//
+// 📄 SwiftUIMDButtonIcon.swift
+// 👨🏼‍💻 Author: Tobias Gleiss
+//
+
+import Foundation
+import SwiftUI
+
+public struct SwiftUIMDButtonIcon: View {
+
+    let icon: Image
+    let position: SwiftUIMDButtonIconPosition
+
+    private let width: Double
+    private let height: Double
+    private let topOffset: CGFloat
+    private let bottomOffset: CGFloat
+
+    /// The icon for a SwiftUI Material Design Button.
+    /// - Parameters:
+    ///   - icon: The image to use as the icon of the button
+    ///   - position: The position of the icon relative to the button title
+    ///   - width: The maximum width of the icon (will be scaled to fit)
+    ///   - height: The maximum height of the icon (will be scaled to fit)
+    ///   - verticalOffset: The vertical offset of the icon relative to the button
+    public init?(icon: Image?, position: SwiftUIMDButtonIconPosition, width: Double, height: Double, verticalOffset: Double = 0) {
+        guard let icon else { return nil }
+        self.icon = icon
+        self.position = position
+        self.width = width
+        self.height = height
+        self.topOffset = verticalOffset > 0 ? verticalOffset : 0
+        self.bottomOffset = verticalOffset < 0 ? (verticalOffset * -1) : 0
+    }
+
+    /// The icon for a SwiftUI Material Design Button.
+    /// - Parameters:
+    ///   - icon: The image to use as the icon of the button
+    ///   - position: The position of the icon relative to the button title
+    ///   - size: The maximum width and height of the icon (will be scaled to fit)
+    ///   - verticalOffset: The vertical offset of the icon relative to the button
+    public init?(icon: Image?, position: SwiftUIMDButtonIconPosition, size: Double, verticalOffset: Double = 0) {
+        self.init(icon: icon, position: position, width: size, height: size, verticalOffset: verticalOffset)
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: topOffset)
+
+            icon
+                .resizable()
+                .frame(maxWidth: width, maxHeight: height, alignment: .center)
+
+            Spacer(minLength: bottomOffset)
+        }
+    }
+
+}
+
+public enum SwiftUIMDButtonIconPosition {
+
+    case leading
+    case trailing
+
+}

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDActivityIndicator.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDActivityIndicator.swift
@@ -10,7 +10,7 @@ public struct SwiftUIMDActivityIndicator: View {
     @Environment(\.activityIndicatorColor) private var color: Color
     @Environment(\.activityIndicatorDiameter) private var diameter: CGFloat
     @Environment(\.activityIndicatorStrokeWidth) private var strokeWidth: CGFloat
-    
+
     @Binding private var isActive: Bool
 
     // Animation States
@@ -69,7 +69,7 @@ public struct SwiftUIMDActivityIndicator: View {
             .onAnimationCompleted(for: animatedRotation, onCompletionExecute: restartAnimationLoop)
             .onChange(of: isActive, perform: animationStateChanged)
     }
-    
+
     private func animationStateChanged(to animated: Bool) {
         if animated { startRotationAnimation() }
     }
@@ -105,19 +105,19 @@ public struct SwiftUIMDActivityIndicator: View {
         }
         startRotationAnimation()
     }
-    
+
     private func finishAnimation() {
         var transaction = Transaction(animation: springAnimation)
         transaction.disablesAnimations = true
         withTransaction(transaction) { trimEnd = 1 }
     }
-    
+
 }
 
 struct SwiftUIMDActivityIndicator_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         SwiftUIMDActivityIndicator()
     }
-    
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
@@ -28,6 +28,7 @@ public struct SwiftUIMDButton: View {
     let rippleEffectScalingAnimation: Animation = .easeIn(duration: 0.3)
     let rippleEffectFadeOutAnimation: Animation = .easeInOut(duration: 0.2)
     let titleOpacityAnimation: Animation = .easeIn(duration: 0.15)
+    let dragArea: CGRect
 
     // Button Styling
     let style: MDButtonStyle
@@ -39,7 +40,9 @@ public struct SwiftUIMDButton: View {
     let rippleEffectColor: Color
     let pendingIndicatorColor: Color
     let elevationShadowColor: Color
-    let isRippleEffectDisabled: Bool // TODO: Invert logic to be positive --> isRippleEffectEnabled
+    let isRippleEffectEnabled: Bool
+    let isAlignedTextButton: Bool
+    let isButtonShapeRemoved: Bool
 
     // Button Content
     let title: String
@@ -52,9 +55,6 @@ public struct SwiftUIMDButton: View {
     // Computed Properties
     var backgroundColor: Color { isEnabled ? style.buttonColor.normal : style.buttonColor.disabled }
     var titleColor: Color { isEnabled ? style.textColor.normal : style.textColor.disabled }
-    var isAlignedTextButton: Bool { style.isText && style.buttonAlignment != .center } // TODO: This doesn't have to be computed!
-    var isButtonShapeRemoved: Bool { isRippleEffectDisabled || isAlignedTextButton } // TODO: This doesn't have to be computed & invert logic to be positive: useButtonShape
-    var dragArea: CGRect { CGRect(x: 0, y: 0, width: width, height: height) } // TODO: Does this have to be computed?
 
     /// The SwiftUI Material Design Button
     /// - Parameters:
@@ -63,7 +63,7 @@ public struct SwiftUIMDButton: View {
     ///   - icon: The icon to display alongside the button title
     ///   - width: The width of the button
     ///   - height: The height of the button
-    ///   - isRippleEffectDisabled: Indicates if the RippleEffect should be disabled
+    ///   - isRippleEffectEnabled: Indicates if the RippleEffect should be enabled
     ///   - action: The action that is executed when the user taps the button
     ///
     /// If the button is followed by a `pending` view modifier, it will be overlayed with an Activity Indicator replacing the title and icon for as long as it is in pending state. A typical use case would look like this:
@@ -87,14 +87,14 @@ public struct SwiftUIMDButton: View {
     ///     }
     ///
     /// - Attention: If the style is set to `.text` and it´s property `horizontalAlignment` is set to `.leading` or `.trailing` the ripple effect will automatically be disabled as well as the button shape. Only a centered text button has the ability to have a RippleEffect.
-    public init(title: String, style: MDButtonStyle = .contained(), icon: SwiftUIMDButtonIcon? = nil, width: CGFloat = SwiftUIMDButton.defaultWidth, height: CGFloat = SwiftUIMDButton.defaultHeight, isRippleEffectDisabled: Bool = false, action: @escaping () -> Void = { }) {
+    public init(title: String, style: MDButtonStyle = .contained(), icon: SwiftUIMDButtonIcon? = nil, width: CGFloat = SwiftUIMDButton.defaultWidth, height: CGFloat = SwiftUIMDButton.defaultHeight, isRippleEffectEnabled: Bool = true, action: @escaping () -> Void = { }) {
         self.title = title
         self.style = style
         self.leadingIcon = icon?.position == .leading ? icon : nil
         self.trailingIcon = icon?.position == .trailing ? icon : nil
         self.width = width
         self.height = height
-        self.isRippleEffectDisabled = isRippleEffectDisabled
+        self.isRippleEffectEnabled = isRippleEffectEnabled
         self.action = action
         self.touchLocation = CGPoint(x: height / 2, y: width / 2)
         self.cornerRadius = style.buttonCornerRadius
@@ -103,6 +103,9 @@ public struct SwiftUIMDButton: View {
         self.rippleEffectColor = style.rippleEffectColor.whileActive
         self.pendingIndicatorColor = style.pendingIndicatorColor
         self.elevationShadowColor = style.buttonElevationShadow.color
+        self.isAlignedTextButton = style.isText && style.buttonAlignment != .center
+        self.dragArea = CGRect(x: 0, y: 0, width: width, height: height)
+        self.isButtonShapeRemoved = !isRippleEffectEnabled || isAlignedTextButton
     }
 
     public var body: some View {

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
@@ -39,35 +39,34 @@ public struct SwiftUIMDButton: View {
     let rippleEffectColor: Color
     let pendingIndicatorColor: Color
     let elevationShadowColor: Color
-    let leadingIcon: Image?
-    let trailingIcon: Image?
-    let isRippleEffectDisabled: Bool
-    
+    let isRippleEffectDisabled: Bool // TODO: Invert logic to be positive --> isRippleEffectEnabled
+
+    // Button Content
+    let title: String
+    let leadingIcon: SwiftUIMDButtonIcon?
+    let trailingIcon: SwiftUIMDButtonIcon?
+
+    // Button Action
+    let action: () -> Void
+
     // Computed Properties
     var backgroundColor: Color { isEnabled ? style.buttonColor.normal : style.buttonColor.disabled }
     var titleColor: Color { isEnabled ? style.textColor.normal : style.textColor.disabled }
-    var isAlignedTextButton: Bool { style.isText && style.buttonAlignment != .center }
-    var isButtonShapeRemoved: Bool { isRippleEffectDisabled || isAlignedTextButton}
-    var dragArea: CGRect { CGRect(x: 0, y: 0, width: width, height: height) }
-    
-    // Button Content
-    let title: String
-    
-    // Button Action
-    let action: () -> Void
-    
-    /// A Material Design button in SwiftUI
+    var isAlignedTextButton: Bool { style.isText && style.buttonAlignment != .center } // TODO: This doesn't have to be computed!
+    var isButtonShapeRemoved: Bool { isRippleEffectDisabled || isAlignedTextButton } // TODO: This doesn't have to be computed & invert logic to be positive: useButtonShape
+    var dragArea: CGRect { CGRect(x: 0, y: 0, width: width, height: height) } // TODO: Does this have to be computed?
+
+    /// The SwiftUI Material Design Button
     /// - Parameters:
     ///   - title: The text appearing on the button
-    ///   - style: The button style (see MDButtonStyle for options).
-    ///   - customHeight: The height of the button.
-    ///   - customWidth: The width of the button.
-    ///   - leadingIcon: The image which is displayed as a leading icon.
-    ///   - trailingIcon: The image which is displayed as a trailing icon.
-    ///   - disableRippleEffect: If the RippleEffect should be disabled.
-    ///   - action: The action that is executed when the user taps the button.
+    ///   - style: The button style (see `MDButtonStyle` for options)
+    ///   - icon: The icon to display alongside the button title
+    ///   - width: The width of the button
+    ///   - height: The height of the button
+    ///   - isRippleEffectDisabled: Indicates if the RippleEffect should be disabled
+    ///   - action: The action that is executed when the user taps the button
     ///
-    /// If the button is followed by a `pending`, it will be overlayed with an Activity Indicator replacing the title for as long as it is in pending state. A typical use case would look like this:
+    /// If the button is followed by a `pending` view modifier, it will be overlayed with an Activity Indicator replacing the title and icon for as long as it is in pending state. A typical use case would look like this:
     ///
     ///     struct ExampleView: View {
     ///
@@ -75,7 +74,7 @@ public struct SwiftUIMDButton: View {
     ///         @State private var isDisabled: Bool = false
     ///
     ///         var body: some View {
-    ///             SwiftUIMDButton("Do stuff", style: .secondary, action: buttonAction)
+    ///             SwiftUIMDButton(title: "Do stuff", style: .secondary, action: togglePending)
     ///                 .pending(isPending)
     ///                 .disabled(isDisabled)
     ///         }
@@ -87,23 +86,23 @@ public struct SwiftUIMDButton: View {
     ///
     ///     }
     ///
-    /// - Attention: If the MDButtonStyle is set to `.text` and it´s property `horizontalAlignment` is set to `.leading` or `.trailing` the RippleEffect will automatically be disabled as well as the button shape. Only a centered text button has the ability to have a RippleEffect. 
-    public init(title: String, style: MDButtonStyle = .contained(), width: CGFloat = SwiftUIMDButton.defaultWidth, height: CGFloat = SwiftUIMDButton.defaultHeight, leadingIcon: Image? = nil, trailingIcon: Image? = nil, disableRippleEffect: Bool = false, action: @escaping () -> Void = { }) {
-        self.touchLocation = CGPoint(x: height / 2, y: width / 2)
+    /// - Attention: If the style is set to `.text` and it´s property `horizontalAlignment` is set to `.leading` or `.trailing` the ripple effect will automatically be disabled as well as the button shape. Only a centered text button has the ability to have a RippleEffect.
+    public init(title: String, style: MDButtonStyle = .contained(), icon: SwiftUIMDButtonIcon? = nil, width: CGFloat = SwiftUIMDButton.defaultWidth, height: CGFloat = SwiftUIMDButton.defaultHeight, isRippleEffectDisabled: Bool = false, action: @escaping () -> Void = { }) {
         self.title = title
-        self.action = action
         self.style = style
+        self.leadingIcon = icon?.position == .leading ? icon : nil
+        self.trailingIcon = icon?.position == .trailing ? icon : nil
         self.width = width
         self.height = height
+        self.isRippleEffectDisabled = isRippleEffectDisabled
+        self.action = action
+        self.touchLocation = CGPoint(x: height / 2, y: width / 2)
         self.cornerRadius = style.buttonCornerRadius
         self.horizontalAlignment = style.buttonAlignment
         self.borderWidth = style.buttonBorderWidth
         self.rippleEffectColor = style.rippleEffectColor.whileActive
         self.pendingIndicatorColor = style.pendingIndicatorColor
         self.elevationShadowColor = style.buttonElevationShadow.color
-        self.leadingIcon = leadingIcon
-        self.trailingIcon = trailingIcon
-        self.isRippleEffectDisabled = disableRippleEffect
     }
 
     public var body: some View {

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
@@ -16,6 +16,7 @@ public struct SwiftUIMDButton: View {
     public static let defaultHeight: CGFloat = 45
 
     // View States
+    @State private var isSetupComplete = false
     @State private var isPressed = false
     @State private var showIndicator = false
     @State private var touchLocation: CGPoint
@@ -111,6 +112,8 @@ public struct SwiftUIMDButton: View {
     public var body: some View {
         alignedButton
             .frame(maxWidth: .infinity)
+            .onChange(of: isPending, perform: pendingStateChanged)
+            .onAppear(perform: setInitialPendingState)
     }
 
     private var alignedButton: some View {
@@ -123,10 +126,9 @@ public struct SwiftUIMDButton: View {
                 .conditionalFrameWidth(width, if: !isAlignedTextButton)
                 .frame(height: height)
                 .cornerRadius(cornerRadius)
-                .onChange(of: isPending, perform: pendingStateChanged)
-                .onAnimationCompleted(for: titleOpacity, onCompletionExecute: resetButtonTitleAnimation)
                 .shadow(color: elevationShadowColor.opacity(elevationShadowOpacity), radius: elevationShadowRadius, x: 0, y: elevationShadowOffset)
                 .increaseTapArea(tapAreaInsets)
+                .onAnimationCompleted(for: titleOpacity, onCompletionExecute: resetButtonTitleAnimation)
                 .onTouchGesture(onStarted: gestureStarted, onLocationUpdate: updateTouchLocation, onEnded: gestureEnded, onCancelled: gestureCancelled)
 
             Spacer()
@@ -213,11 +215,27 @@ public struct SwiftUIMDButton: View {
         }
     }
 
+    /// Update the Pending Indicator when the button appears (used from the `.onAppear` modifier).
+    private func setInitialPendingState() {
+        guard !isSetupComplete else { return }
+        pendingStateChanged(to: isPending, after: 0.0)
+    }
+
+    /// Update the Pending Indicator with the default delay (used from the `.onChange` modifier).
+    /// - Parameter pending: The new pending state
     private func pendingStateChanged(to pending: Bool) {
+        pendingStateChanged(to: pending, after: isButtonShapeRemoved ? 0.0 : 0.3)
+    }
+
+    /// Update the Pending Indicator.
+    /// - Parameters:
+    ///   - pending: The new pending state
+    ///   - delayInSeconds: The delay to start and stop the animation (used to wait for the ripple effect to finish first)
+    private func pendingStateChanged(to pending: Bool, after delayInSeconds: Double) {
         if pending {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showIndicator = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + delayInSeconds) { showIndicator = true }
         } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showIndicator = false }
+            DispatchQueue.main.asyncAfter(deadline: .now() + delayInSeconds) { showIndicator = false }
         }
     }
 

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDButton.swift
@@ -6,29 +6,29 @@
 import SwiftUI
 
 public struct SwiftUIMDButton: View {
-    
+
     @Environment(\.isButtonPending) private var isPending: Bool
     @Environment(\.isEnabled) private var isEnabled: Bool
     @Environment(\.buttonTapAreaInsets) private var tapAreaInsets: EdgeInsets
-    
+
     // Default values
     public static let defaultWidth: CGFloat = 300
     public static let defaultHeight: CGFloat = 45
-    
+
     // View States
-    @State private var isPressed: Bool = false
-    @State private var showIndicator: Bool = false
+    @State private var isPressed = false
+    @State private var showIndicator = false
     @State private var touchLocation: CGPoint
     @State private var elevationShadowRadius: CGFloat = 0
     @State private var elevationShadowOffset: CGFloat = 0
     @State private var elevationShadowOpacity: CGFloat = 0
     @State private var titleOpacity: CGFloat = 1
-    
+
     // Animations
     let rippleEffectScalingAnimation: Animation = .easeIn(duration: 0.3)
     let rippleEffectFadeOutAnimation: Animation = .easeInOut(duration: 0.2)
     let titleOpacityAnimation: Animation = .easeIn(duration: 0.15)
-    
+
     // Button Styling
     let style: MDButtonStyle
     let borderWidth: CGFloat
@@ -105,17 +105,17 @@ public struct SwiftUIMDButton: View {
         self.trailingIcon = trailingIcon
         self.isRippleEffectDisabled = disableRippleEffect
     }
-    
+
     public var body: some View {
         alignedButton
             .frame(maxWidth: .infinity)
     }
-    
+
     private var alignedButton: some View {
         HStack {
             Spacer()
                 .hidden(horizontalAlignment == .leading, andRemoved: true)
-            
+
             button
                 .contentShape(Rectangle())
                 .conditionalFrameWidth(width, if: !isAlignedTextButton)
@@ -126,23 +126,23 @@ public struct SwiftUIMDButton: View {
                 .shadow(color: elevationShadowColor.opacity(elevationShadowOpacity), radius: elevationShadowRadius, x: 0, y: elevationShadowOffset)
                 .increaseTapArea(tapAreaInsets)
                 .onTouchGesture(onStarted: gestureStarted, onLocationUpdate: updateTouchLocation, onEnded: gestureEnded, onCancelled: gestureCancelled)
-            
+
             Spacer()
                 .hidden(horizontalAlignment == .trailing, andRemoved: true)
         }
     }
-    
+
     private var button: some View {
         ZStack {
             buttonBackgroundShape
-            
+
             SwiftUIMDRippleEffect(isPressed: $isPressed, tapLocation: $touchLocation, rippleEffectColor: rippleEffectColor)
                 .hidden(isButtonShapeRemoved, andRemoved: true)
-                
+
             buttonTitleContent
         }
     }
-    
+
     @ViewBuilder private var buttonBackgroundShape: some View {
         switch style {
         case .contained: containedButtonBackground
@@ -150,7 +150,7 @@ public struct SwiftUIMDButton: View {
         case .text: EmptyView()
         }
     }
-    
+
     @ViewBuilder private var buttonTitleContent: some View {
         if showIndicator {
             SwiftUIMDActivityIndicator()
@@ -159,50 +159,50 @@ public struct SwiftUIMDButton: View {
             HStack {
                 leadingIcon
                     .foregroundColor(titleColor)
-               
+
                 Text(title)
                     .foregroundColor(titleColor)
                     .font(style.buttonFont)
                     .fontWeight(.bold)
                     .opacity(titleOpacity)
-                
+
                 trailingIcon
                     .foregroundColor(titleColor)
             }
         }
     }
-    
+
     private var containedButtonBackground: some View {
         RoundedRectangle(cornerRadius: cornerRadius)
             .foregroundColor(backgroundColor)
     }
-    
+
     private var outlinedButtonBackground: some View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             .stroke(backgroundColor, lineWidth: borderWidth)
     }
-    
+
     private var textButtonBackground: some View {
         Rectangle()
     }
-    
-    // MARK:  Private View Logic
-    
+
+    // MARK: Private View Logic
+
     private func updateTouchLocation(to location: CGPoint) {
         touchLocation = location
     }
-    
+
     private func gestureStarted() {
         startButtonRippleEffectAnimation()
         startButtonTitleTapAnimation()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { startButtonElevationAnimation() }
     }
-    
+
     private func gestureCancelled() {
         endButtonRippleEffectAnimation()
         resetButtonElevationAnimation()
     }
-    
+
     private func gestureEnded() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             endButtonRippleEffectAnimation()
@@ -210,7 +210,7 @@ public struct SwiftUIMDButton: View {
             resetButtonElevationAnimation()
         }
     }
-    
+
     private func pendingStateChanged(to pending: Bool) {
         if pending {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showIndicator = true }
@@ -218,7 +218,7 @@ public struct SwiftUIMDButton: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showIndicator = false }
         }
     }
-    
+
     private func startButtonTitleTapAnimation() {
         if isButtonShapeRemoved {
             var transaction = Transaction(animation: titleOpacityAnimation)
@@ -228,15 +228,15 @@ public struct SwiftUIMDButton: View {
             }
         }
     }
-    
+
     private func startButtonRippleEffectAnimation() {
         isPressed = true
     }
-    
+
     private func endButtonRippleEffectAnimation() {
         isPressed = false
     }
-    
+
     private func startButtonElevationAnimation() {
         var transaction = Transaction(animation: .default)
         transaction.disablesAnimations = true
@@ -246,13 +246,13 @@ public struct SwiftUIMDButton: View {
             elevationShadowOpacity = 1
         }
     }
-    
+
     private func resetButtonElevationAnimation() {
         elevationShadowOffset = 0
         elevationShadowRadius = 0
         elevationShadowOpacity = 0
     }
-    
+
     private func resetButtonTitleAnimation() {
         var transaction = Transaction(animation: titleOpacityAnimation)
         transaction.disablesAnimations = true
@@ -260,12 +260,12 @@ public struct SwiftUIMDButton: View {
             titleOpacity = 1
         }
     }
-    
+
 }
 
 // Implementation inspired by https://www.hackingwithswift.com/quick-start/swiftui/how-to-detect-the-location-of-a-tap-inside-a-view
 struct TouchLocationView: UIViewRepresentable {
-    
+
     struct TouchType: OptionSet {
         let rawValue: Int
         static let started = TouchType(rawValue: 1)
@@ -273,14 +273,14 @@ struct TouchLocationView: UIViewRepresentable {
         static let cancelled = TouchType(rawValue: 3)
         static let all: TouchType = [.started, .ended, .cancelled]
     }
-    
+
     let onStarted: () -> Void
     let onLocationUpdate: (CGPoint) -> Void
     let onEnded: () -> Void
     let onCancelled: () -> Void
-    
+
     let types = TouchType.all
-    
+
     func makeUIView(context: Context) -> TouchLocationUIView {
         let view = TouchLocationUIView()
         view.onStarted = onStarted
@@ -290,44 +290,45 @@ struct TouchLocationView: UIViewRepresentable {
         view.touchTypes = types
         return view
     }
-    
+
     func updateUIView(_ uiView: TouchLocationUIView, context: Context) { }
-    
+
     class TouchLocationUIView: UIView {
+
         var onStarted: (() -> Void)?
         var onLocationUpdate: ((CGPoint) -> Void)?
         var onEnded: (() -> Void)?
         var onCancelled: (() -> Void)?
         var touchTypes: TouchLocationView.TouchType = .all
-        
+
         override init(frame: CGRect) {
             super.init(frame: frame)
             isUserInteractionEnabled = true
         }
-        
+
         required init?(coder: NSCoder) {
             super.init(coder: coder)
             isUserInteractionEnabled = true
         }
-        
+
         override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
             guard let touch = touches.first else { return }
             let location = touch.location(in: self)
             determineAction(with: location, forEvent: .started)
         }
-        
+
         override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
             guard let touch = touches.first else { return }
             let location = touch.location(in: self)
             determineAction(with: location, forEvent: .ended)
         }
-        
+
         override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
             guard let touch = touches.first else { return }
             let location = touch.location(in: self)
             determineAction(with: location, forEvent: .cancelled)
         }
-        
+
         private func determineAction(with location: CGPoint, forEvent event: TouchType) {
             guard touchTypes.contains(event) else { return }
             onLocationUpdate?(location)
@@ -335,8 +336,10 @@ struct TouchLocationView: UIViewRepresentable {
             case .started: onStarted?()
             case .ended: onEnded?()
             case .cancelled: onCancelled?()
-            default: do {}
+            default: do { }
             }
         }
+
     }
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDRippleEffect.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDRippleEffect.swift
@@ -6,26 +6,26 @@
 import SwiftUI
 
 public struct SwiftUIMDRippleEffect: View {
-    
+
     // Default values
     let defaultScaling: CGFloat = 3
     let defaultOpacity: CGFloat = 0
-    
+
     // View States
     @Binding private var isPressed: Bool
     @Binding private var tapLocation: CGPoint
     @Binding private var animationCompletedCallback: Bool
     @State private var scaling: CGFloat
     @State private var opacity: CGFloat
-    @State private var animationCompleted: Bool = true
-    
+    @State private var animationCompleted = true
+
     // Properties
     let color: Color
-    
+
     // Animations
     let scalingAnimation: Animation = .easeIn(duration: 0.25)
     let fadeOutAnimation: Animation = .easeInOut(duration: 0.2)
-    
+
     /// A Material Design Ripple Effect in SwiftUI.
     /// - Parameters:
     ///   - isPressed: A Binding which indicates if the Ripple Effect should be started.
@@ -41,7 +41,7 @@ public struct SwiftUIMDRippleEffect: View {
         self.color = rippleEffectColor
         self._animationCompletedCallback = isFinished
     }
-    
+
     public var body: some View {
         Circle()
             .scale(scaling)
@@ -52,7 +52,7 @@ public struct SwiftUIMDRippleEffect: View {
             .onChange(of: isPressed, perform: pressedStateChanged)
             .onAnimationCompleted(for: opacity, onCompletionExecute: markAnimationCompleted)
     }
-    
+
     private func pressedStateChanged(to isPressed: Bool) {
         if isPressed {
             startRippleEffectScalingAnimation()
@@ -60,7 +60,7 @@ public struct SwiftUIMDRippleEffect: View {
             finishRippleEffectAnimation()
         }
     }
-    
+
     private func startRippleEffectScalingAnimation() {
         animationCompleted = false
         animationCompletedCallback = false
@@ -72,7 +72,7 @@ public struct SwiftUIMDRippleEffect: View {
             scaling = 30
         }
     }
-    
+
     private func finishRippleEffectAnimation() {
         guard animationCompleted else { return }
         var transaction = Transaction(animation: scalingAnimation)
@@ -82,11 +82,11 @@ public struct SwiftUIMDRippleEffect: View {
             scaling = defaultScaling
         }
     }
-    
+
     private func markAnimationCompleted() {
         animationCompleted = true
         animationCompletedCallback = true
         if !isPressed { finishRippleEffectAnimation() }
     }
-    
+
 }

--- a/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDTextField.swift
+++ b/Sources/SwiftUIMaterialDesignComponents/SwiftUIMDTextField.swift
@@ -6,29 +6,29 @@
 import SwiftUI
 
 public struct SwiftUIMDTextField: View {
-    
+
     // View States
     @State var isSlashed: Bool
-    
+
     @Binding var value: String
     @Environment(\.textFieldErrorMessage) private var errorMessage: String
     @Environment(\.isEnabled) private var isEnabled
-    
-    //Animation States
+
+    // Animation States
     @State var placeholderFontSize = CGFloat(16)
     @State var placeholderOffset = CGSize(width: 0, height: 0)
     @State var placeholderColor: Color
     @State var borderWidth = CGFloat(1)
     @State var borderColor: Color
-    
+
     // Constant Properties
     private let placeholderText: String
     private let onEditingChanged: (Bool) -> Void
     private let onCommit: () -> Void
-    
+
     // Computed Properties
-    private var isErrorStateSet: Bool { errorMessage != "" ? true : false}
-    
+    private var isErrorStateSet: Bool { errorMessage != "" ? true : false }
+
     // TextField General Styling
     private var style: MDTextFieldStyle
     private let textFieldHeight: CGFloat
@@ -40,9 +40,9 @@ public struct SwiftUIMDTextField: View {
     private let horizontalPadding: CGFloat
     private let verticalPadding: CGFloat
     private let errorMessageFontSize: CGFloat
-    
+
     // TextField Colors
-    
+
     private let textColor: Color
     private let textColorDisabled: Color
     private let backgroundColor: Color
@@ -51,7 +51,7 @@ public struct SwiftUIMDTextField: View {
     private let focusedColor: Color
     private let errorMessageColor: Color
     private let errorMessageBackgroundColor: Color
-    
+
     /// A Material Design Text Field in SwiftUI
     /// - Parameters:
     ///   - placeholder: The placeholder text appearing on the text field.
@@ -80,7 +80,7 @@ public struct SwiftUIMDTextField: View {
     ///
     ///     }
     ///
-    public init(placeholder: String, style: MDTextFieldStyle = .filled(), value: Binding<String>, icon: Image? = nil, securedIcon: (slashed: Image, unslashed: Image)? = (Image(systemName: "eye.slash.fill"), Image(systemName: "eye.fill")), onEditingChanged: @escaping (Bool) -> Void = { _ in }, onCommit: @escaping () -> Void = {} ) {
+    public init(placeholder: String, style: MDTextFieldStyle = .filled(), value: Binding<String>, icon: Image? = nil, securedIcon: (slashed: Image, unslashed: Image)? = (Image(systemName: "eye.slash.fill"), Image(systemName: "eye.fill")), onEditingChanged: @escaping (Bool) -> Void = { _ in }, onCommit: @escaping () -> Void = { }) {
         self.placeholderText = placeholder
         self.style = style
         self._value = value
@@ -107,60 +107,60 @@ public struct SwiftUIMDTextField: View {
         self.errorMessageFontSize = style.errorMessageFontSize
         self.isSlashed = style.isSecured
     }
-    
+
     public var body: some View {
         container
     }
-    
+
     @ViewBuilder var container: some View {
         VStack(alignment: .leading) {
-            
+
             content
                 .padding(.horizontal, horizontalPadding)
                 .background(
                     backgroundLayer
                 )
-            
+
             errorMessageView
                 .padding(.horizontal, horizontalPadding)
         }
     }
-    
+
     @ViewBuilder private var backgroundLayer: some View {
         switch style {
         case .filled, .filledSecured: filledBackground
         case .outlined, .outlinedSecured: outlinedBackground
         }
     }
-    
+
     private var filledBackground: some View {
         currentBackgroundColor
             .cornerRadius(cornerRadius, corners: .topLeft)
             .cornerRadius(cornerRadius, corners: .topRight)
             .overlay(bottomBorder, alignment: .bottom)
     }
-    
+
     private var currentBackgroundColor: some View {
         guard isEnabled else { return backgroundColorDisabled }
         return isErrorStateSet ? errorMessageBackgroundColor : backgroundColor
     }
-    
+
     private var outlinedBackground: some View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             .stroke(borderColor, lineWidth: borderWidth)
     }
-    
+
     private var bottomBorder: some View {
         Rectangle()
             .frame(height: borderWidth)
             .foregroundColor(isEnabled ? borderColor : borderColorDisabled)
     }
-    
+
     private var content: some View {
         HStack {
             textFieldContainer
                 .frame(height: textFieldHeight)
-            
+
             Spacer()
 
             iconView
@@ -170,13 +170,13 @@ public struct SwiftUIMDTextField: View {
                 .animation(.default, value: isSlashed)
         }
     }
-    
+
     private var errorMessageView: some View {
         Text(errorMessage)
             .foregroundColor(errorMessageColor)
             .font(.system(size: errorMessageFontSize))
     }
-    
+
     private var textFieldContainer: some View {
         ZStack(alignment: .leading) {
             Text(placeholderText)
@@ -184,12 +184,12 @@ public struct SwiftUIMDTextField: View {
                 .font(.system(size: placeholderFontSize))
                 .background(placeholderBackground)
                 .offset(placeholderOffset)
-            
+
             textFieldView
                 .foregroundColor(textColor)
         }
     }
-    
+
     @ViewBuilder private var textFieldView: some View {
         if #available(iOS 15.0, *) {
             TextFieldiOS15(isSlashed: $isSlashed, textFieldValue: $value, onFocusChange: focusStateChanged, onCommit: onCommit)
@@ -197,89 +197,87 @@ public struct SwiftUIMDTextField: View {
             TextFieldiOS14(isSlashed: $isSlashed, textFieldValue: $value, onFocusChange: focusStateChanged, onCommit: onCommit)
         }
     }
-    
+
     @available(iOS 15.0, *)
     private struct TextFieldiOS15: View {
-        
+
         @Binding var isSlashed: Bool
         @Binding var textFieldValue: String
         var onFocusChange: (Bool) -> Void
         var onCommit: () -> Void
         @FocusState var isFocused: Bool
-        
+
         public var body: some View {
             textField
                 .onChange(of: isFocused, perform: onFocusChange)
                 .focused($isFocused)
                 .onSubmit(onCommit)
         }
-        
+
         @ViewBuilder private var textField: some View {
             if isSlashed {
                 SecureField("", text: $textFieldValue)
-            }
-            else {
+            } else {
                 TextField("", text: $textFieldValue)
             }
         }
-        
+
         private func submitValue() {
             onCommit()
         }
     }
-    
+
     private struct TextFieldiOS14: View {
-        
+
         @Binding var isSlashed: Bool
         @Binding var textFieldValue: String
         var onFocusChange: (Bool) -> Void
         var onCommit: () -> Void
-        
-        @State var isFocused: Bool = false
-        
+
+        @State var isFocused = false
+
         public var body: some View {
             textField
                 .onChange(of: isFocused, perform: onFocusChange)
                 .onTapGesture(perform: setFocus)
         }
-        
+
         @ViewBuilder private var textField: some View {
             if isSlashed {
                 SecureField("", text: $textFieldValue, onCommit: submitValue)
-            }
-            else {
+            } else {
                 TextField("", text: $textFieldValue, onCommit: submitValue)
             }
         }
-        
+
         private func setFocus() {
             isFocused = true
             print("true")
         }
-        
+
         private func submitValue() {
             onCommit()
             hideKeyboard()
-            
+
             isFocused = false
             print("false")
         }
     }
-    
+
     @ViewBuilder private var placeholder: some View {
         Text(placeholderText)
             .foregroundColor(placeholderColor)
             .font(.system(size: placeholderFontSize))
             .background(placeholderBackground)
     }
-    
+
     @ViewBuilder private var placeholderBackground: some View {
         switch style {
         case .filled, .filledSecured: Color.clear
         case .outlined, .outlinedSecured: Color.white
         }
     }
-    
+
     @ViewBuilder private var iconView: some View {
         if style == .filledSecured() || style == .outlinedSecured() {
             secureIconView?
@@ -290,33 +288,31 @@ public struct SwiftUIMDTextField: View {
                 .resizable()
         }
     }
-    
+
     @ViewBuilder private var secureIconView: Image? {
         isSlashed ? secureIcon?.slashed : secureIcon?.unslashed
     }
-    
+
     private func focusStateChanged(to isFocused: Bool) {
         if isErrorStateSet {
             placeholderColor = style.textColor
             borderColor = errorMessageColor
             borderWidth = 1
-        }
-        else if isFocused {
+        } else if isFocused {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 switch style {
                 case .filled, .filledSecured: startFocusedAnimationForFilled()
                 case .outlined, .outlinedSecured: startFocusedAnimationForOutlined()
                 }
             }
-        }
-        else if value == "" {
+        } else if value == "" {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 resetFocusedAnimation()
             }
         }
         onEditingChanged(isFocused)
     }
-    
+
     private func startFocusedAnimationForFilled() {
         var transaction = Transaction(animation: .easeIn(duration: 0.2))
         transaction.disablesAnimations = true
@@ -328,7 +324,7 @@ public struct SwiftUIMDTextField: View {
             borderColor = style.focusedColor
         }
     }
-    
+
     private func startFocusedAnimationForOutlined() {
         var transaction = Transaction(animation: .easeIn(duration: 0.2))
         transaction.disablesAnimations = true
@@ -340,7 +336,7 @@ public struct SwiftUIMDTextField: View {
             borderColor = style.focusedColor
         }
     }
-    
+
     private func resetFocusedAnimation() {
         var transaction = Transaction(animation: .easeIn(duration: 0.2))
         transaction.disablesAnimations = true
@@ -352,7 +348,7 @@ public struct SwiftUIMDTextField: View {
             borderColor = style.borderColor
         }
     }
-    
+
     private func toggleSlashedInput() {
         isSlashed.toggle()
     }


### PR DESCRIPTION
- Respect initial state of the environment variable that defines the pending state of the Button.
- Improve performance by converting computed properties that never change their value to constants.
- Improve Button Icon definition by extracting it to its own type.
- Unrelated: Add SwiftFormat rules (have to be run manually right now)
- Unrelated: Improve gitignore rules
- Unrelated: Fix broken README following branch reorganization

Closes #17.